### PR TITLE
Feature/sass grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,15 +4,6 @@ module.exports = function(grunt) {
         jshint: {
             files: ['Gruntfile.js', 'assets/js/*.js', 'package.json'],
         },
-        phpcs: {
-            application: {
-                src: ['*.php', '**/*.php']
-            },
-            options: {
-                bin: '/usr/bin/phpcs',
-                standard: 'Wordpress'
-            }
-        },
 		sass: {
 			dist: {
                 options: {
@@ -31,10 +22,6 @@ module.exports = function(grunt) {
             javascript: {
                 files: ['<%= jshint.files %>'],
                 tasks: ['changed:jshint']
-            },
-            php: {
-                files: ['*.php','**/*.php'],
-                tasks: ['changed:phpcs']
             }
 		}
 	});

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,6 @@
 module.exports = function(grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
-        jshint: {
-            files: ['Gruntfile.js', 'assets/js/*.js', 'package.json'],
-        },
 		sass: {
 			dist: {
                 options: {
@@ -18,17 +15,11 @@ module.exports = function(grunt) {
 			css: {
 				files: '**/*.scss',
 				tasks: ['sass']
-			},
-            javascript: {
-                files: ['<%= jshint.files %>'],
-                tasks: ['changed:jshint']
-            }
+			}
 		}
 	});
 	grunt.loadNpmTasks('grunt-changed');
-	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-sass');
 	grunt.loadNpmTasks('grunt-contrib-watch');
-	grunt.loadNpmTasks('grunt-phpcs');
 	grunt.registerTask('default',['watch']);
 };

--- a/package.json
+++ b/package.json
@@ -4,11 +4,8 @@
   "devDependencies": {
     "grunt": "*",
     "grunt-changed": "*",
-    "grunt-contrib-jshint": "*",
     "grunt-contrib-sass": "*",
     "grunt-contrib-watch": "*",
-    "grunt-phpcs": "*",
-    "jshint": "*",
     "sass": "^1.14.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "grunt-contrib-sass": "*",
     "grunt-contrib-watch": "*",
     "grunt-phpcs": "*",
-    "jshint": "*"
+    "jshint": "*",
+    "sass": "^1.14.3"
   }
 }


### PR DESCRIPTION
This remove linters for PHP and JS. I could try to get the jshint working again, but I'm not going to attempt PHPCodesniffer on UA hosts. I could also look into minifying the resulting css if you'd like. (Google doc is updated on how to get grunt / sass up and running on UA hosts.)