### PR TITLE
0047 fix - Expand accordions for printing

### DIFF
--- a/isc-styles.css
+++ b/isc-styles.css
@@ -1199,3 +1199,9 @@ a.uw-btn.btn-sm.btn-left {
   overflow: hidden;
   transition: height 0.35s ease;
 }
+
+@media print{
+  .collapse{
+    display:block;
+  }
+}


### PR DESCRIPTION
Collapsed (hidden) elemets should be included while printing the page.