### PR TITLE
ISC-13353 Change position of H1 title in the "User Guide" page template

### DIFF
--- a/isc-styles.css
+++ b/isc-styles.css
@@ -1544,7 +1544,7 @@ font-weight: normal;
   margin-top: 1em;
 }
 
-h2 {
+.float-content h2:first-of-type {
   margin-top: 0px !important;
 }
 


### PR DESCRIPTION
isc-styles.css: removed h2 top margin from first h2 of article content (div with class 'float-content').