### PR TITLE
ISC-15021 Consistent page header styling across templates

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -123,6 +123,41 @@ function isc_excerpt_more( $excerpt ) {
 }
 
 /**
+ * Echoes the page header: Bread crumbs + Page Title + Last updated time stamp in that order
+ * 
+ *
+ * @param boolean $echo if true then echoes the header HTML, else returns the header HTML.
+ */
+function the_page_header( $echo = true ) {
+	$breadcrumbs_html = get_uw_breadcrumbs();
+	$title_html = isc_title(false);
+	$modified_date = the_modified_date('l, F j, Y', '', '', false);
+
+	$page_header = <<<djajnokdnvn
+	<div class="isc-page-header">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-12">
+					$breadcrumbs_html
+				</div>
+			</div>
+			<div class="title-n-info">
+				$title_html
+				<div class="isc-updated-date">Last updated  $modified_date</div>
+			</div>
+		</div>
+	</div>
+djajnokdnvn;
+	
+   if ( $echo ) {
+	   echo $page_header;
+   } else {
+	   return $page_header;
+   }
+}
+
+
+/**
  * Echoes the title of a page in an h2
  * (removing any potential html elements)
  *

--- a/isc-styles.css
+++ b/isc-styles.css
@@ -1663,3 +1663,16 @@ p:empty{
   display: table;
 }
 /* Named support contact tables - end*/
+
+/* Consistent Page Header - start*/
+
+.isc-page-header .title{
+  color: #85754d;
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.isc-page-header .title-n-info{
+  margin-bottom: 32px;
+}
+/* Consistent Page Header - end*/

--- a/page.php
+++ b/page.php
@@ -6,10 +6,12 @@
  * @author UW-IT AXDD
  */
 
-get_header();
-	  $url = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) );
-	  $sidebar = get_post_meta( $post->ID, 'sidebar' );   ?>
-
+	get_header();
+	$url = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) );
+	$sidebar = get_post_meta( $post->ID, 'sidebar' );   
+	
+	the_page_header();
+?>
 <div role="main">
 
 	<?php uw_site_title(); ?>
@@ -17,12 +19,7 @@ get_header();
 
 	<div class="container uw-body">
 
-		<div class="row">
-			<div class="col-md-12">
-
-				<?php get_template_part( 'breadcrumbs' ); ?>
-			</div>
-		</div>
+	
 
 		<div class="row">
 
@@ -30,20 +27,12 @@ get_header();
 
 				<div id='main_content' class="uw-body-copy" tabindex="-1">
 
-					<?php log_to_console( 'page.php' ) ?>
-
-					<?php isc_title(); ?>
-
-					<?php 
-
-					the_modified_date('l, F j, Y', '<div class="isc-updated-date">Last updated ', '</div>');
-
-					?>
-
 					<?php
+					log_to_console( 'page.php' );
+					
 					// Start the Loop.
-					while ( have_posts() ) : the_post();
-
+					while ( have_posts() ){
+						the_post();
 						the_content();
 
 						// If comments are open or we have at least one comment, load up the comment template.
@@ -51,7 +40,7 @@ get_header();
 							  comments_template();
 						}
 
-					endwhile;
+					}
 					?>
 
 				</div>

--- a/single-glossary.php
+++ b/single-glossary.php
@@ -8,8 +8,11 @@
 
 get_header();
 	  $url = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) );
-	  $sidebar = get_post_meta( $post->ID, 'sidebar' );   ?>
-
+	  $sidebar = get_post_meta( $post->ID, 'sidebar' );
+	  
+	  the_page_header();
+?>
+	  
 <div role="main">
 
 	<?php uw_site_title(); ?>
@@ -17,21 +20,13 @@ get_header();
 
 	<div class="container uw-body">
 
-		<div class="row">
-			<div class="col-md-12">
-				<?php get_template_part( 'breadcrumbs' ); ?>
-			</div>
-		</div>
-
-		<div class="row">
+	<div class="row">
 
 			<div class="uw-content col-md-9">
 
 				<div id='main_content' class="uw-body-copy" tabindex="-1">
 
 					<?php log_to_console( 'single-glossary.php' ) ?>
-
-					<?php isc_title(); ?>
 
 					<div>
 						<?php

--- a/single.php
+++ b/single.php
@@ -8,7 +8,10 @@
 
 get_header();
 	  $url = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) );
-	  $sidebar = get_post_meta( $post->ID, 'sidebar' );   ?>
+	  $sidebar = get_post_meta( $post->ID, 'sidebar' );   
+
+	  the_page_header();
+?>
 
 <div role="main">
 
@@ -18,12 +21,6 @@ get_header();
 	<div class="container uw-body">
 
 		<div class="row">
-			<div class="col-md-12">
-				<?php get_template_part( 'breadcrumbs' ); ?>
-			</div>
-		</div>
-
-		<div class="row">
 
 			<div class="uw-content col-md-9">
 
@@ -31,9 +28,6 @@ get_header();
 
 					<?php log_to_console( 'single.php' ) ?>
 
-					<?php isc_title(); ?>
-
-					<div class="update-date"><?php echo get_the_date() ?></div>
 					<div class="post-content">
 						<?php
 						  // Start the Loop.


### PR DESCRIPTION
functions.php: new function to either print or return page header html, page header is a consistent section that will refer to the bread crumbs + page title + last updated time stamp, in ISC henceforth.
page.php, single.php, single-glossary.php: Page templates that support this consistency.
isc-style.css: styling support