### PR TITLE
ISC-14904 Images resizing too large on mobile

### DIFF
--- a/isc-styles.css
+++ b/isc-styles.css
@@ -2164,3 +2164,12 @@ p:empty {
   margin-bottom: 32px;
 }
 /* Consistent Page Header - end*/
+
+
+/* Icons in content being treated as images resulting to width scaling on smaller screens - start */
+
+.isc-icon{
+    width: auto !important;
+}
+
+/* Icons in content being treated as images resulting to width scaling on smaller screens - end */


### PR DESCRIPTION
isc-styles.css: Use class 'isc-icon' in post editor to prevent this.