### PR TITLE
ISC-15143 "Null" character appearing at the end of hyperlinked text

### DIFF
--- a/isc-styles.css
+++ b/isc-styles.css
@@ -1207,11 +1207,11 @@ a.uw-btn.btn-sm.btn-left {
     position: relative;
 }
 
-.isc-expander a.collapsed:after {
+.isc-expander a[role=button].collapsed:after {
     content: "\f078";
 }
 
-.isc-expander a.expanded:after {
+.isc-expander a[role=button].expanded:after {
     content: "\f077";
 }
 

--- a/style.css
+++ b/style.css
@@ -13,15 +13,15 @@
 */
 
 /* Change chevron character for accordion menus */
-.isc-expander a.expanded::after{
+.isc-expander a[role=button].expanded::after{
     content: "\f13a" !important;
 }
 
-.isc-expander a.collapsed:after {
+.isc-expander a[role=button].collapsed:after {
     content: "\f138" !important;
 }
 
-.isc-expander a:after {
+.isc-expander a[role=button]:after {
     content: "\f138" !important;
 }
 /* Override style for ol's on Event pages */


### PR DESCRIPTION
isc-styles.css, styles.css: applying font-awesom chevron and styling only to the anchor tag that is the accordion's handle (i.e. it has role=button) and not all the anchor tags inside the accordions.