### PR TITLE
ISC-16617 Sitewide style fixes/tweaks

### DIFF
--- a/isc-styles.css
+++ b/isc-styles.css
@@ -287,6 +287,10 @@ p {
 
 a.uw-btn.btn-sm {
     margin-right: 43px !important;
+}
+
+a.uw-btn.btn-sm-top {
+    margin-right: 43px !important;
     margin-top: 10px !important;
 }
 
@@ -322,15 +326,14 @@ a.uw-btn.btn-sm.btn-left {
     margin-top: 30px;
 }
 
-.uw-body h2:first-of-type {
-    margin-top: 0px;
-}
-
 .uw-body h2 a,
 .uw-body h4 a {
     color: #4b2e83;
 }
 
+#main_content > h2:first-of-type {
+    margin-top: 0px;
+}
 
 /*** uw breadcrumbs ***/
 


### PR DESCRIPTION
Revisions:
- For the first H2: Fixed CSS according to the default template where it only affects the immediate first child which is h2
- For a.uw-btn.btn-sm: Created a new class "a.uw-btn.btn-sm-top" which is a duplicate of the original class but has a top margin of 10px