### PR TITLE
ISC-18412 New div class/CSS for responsive embedded YouTube videos

### DIFF
--- a/isc-styles.css
+++ b/isc-styles.css
@@ -24,6 +24,21 @@ p {
 }
 
 
+.responsive-youtube-iframe {
+    position:relative;
+    padding-bottom:56.25%;
+    height:0;
+    overflow:hidden;
+}
+    
+.responsive-youtube-iframe iframe, .responsive-youtube-iframe object, .responsive-youtube-iframe embed {
+    position:absolute;
+    top:0;
+    left:0;
+    width:100%;
+    height:100%;
+}
+
 /*** top banner nav (white bar) ***/
 
 .uw-thinstrip {


### PR DESCRIPTION
Added a CSS class to make the iframe responsive
Use div class responsive-youtube-iframe to make the iframe responsive