### PR TITLE
ISC-31043 Modify Gravity Forms Styling

### DIFF
--- a/isc-styles.css
+++ b/isc-styles.css
@@ -1689,7 +1689,7 @@ h3 > a {
 }
 
 .uw-accordion-menu .has-children {
-    color: red !important;
+    color: #3D3D3D !important;
 }
 
 .uw-accordion-menu .has-children a,


### PR DESCRIPTION
Change TOC "has children" red text to the standard dark gray, sitewide.